### PR TITLE
Added support loading config in windows

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,7 @@
 import * as fs from '@node/fs';
+import path from '@node/path';
+
+const isWindows = typeof process != 'undefined' && process.platform.match(/^win/);
 
 class Config{
 	/**
@@ -9,7 +12,7 @@ class Config{
 		return new Promise((resolve, reject) => {
 			let configPath = config;
 			if (typeof config === 'undefined'){
-				configPath = process.cwd()+"/config/main";
+				configPath = path.join('file://' + (isWindows ? '/' : '') +  process.cwd(), "config", "main");
 			}
 
 			if ((typeof config === 'string') || (typeof config === 'undefined')){


### PR DESCRIPTION
On windows fail import config file. Throws an error - "wrong config data, can not start app"

Problem:
https://github.com/ModuleLoader/es6-module-loader/blob/be03106aac3e2d0a2a08f743fe1f20588fb033aa/src/system-fetch.js#L79

System.import required url - file://path/to/file
Solution found here:
https://github.com/ModuleLoader/es6-module-loader/blob/2e17f6cdb89bd02b19a47375bfc0370d1e1b0dec/test/_helper.js#L27